### PR TITLE
Fix in-flight request merging.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'provided-base'
 
 group = 'com.inkapplications'
-version = '0.0.2'
+version = '0.0.3'
 
 sourceCompatibility = 1.6
 targetCompatibility = 1.6

--- a/src/main/java/com/inkapplications/groundcontrol/CleanupObserver.java
+++ b/src/main/java/com/inkapplications/groundcontrol/CleanupObserver.java
@@ -6,6 +6,7 @@ package com.inkapplications.groundcontrol;
 
 import rx.Observable;
 import rx.Observer;
+import rx.subjects.PublishSubject;
 
 import java.util.HashMap;
 
@@ -22,7 +23,7 @@ import java.util.HashMap;
 final class CleanupObserver<ENTITY> implements Observer<ENTITY>
 {
     /** Stateful storage of in-flight requests. */
-    final private HashMap<String, Observable<ENTITY>> requests;
+    final private HashMap<String, PublishSubject<ENTITY>> requests;
 
     /** Key to remove observables of on completion. */
     final private String key;
@@ -31,7 +32,7 @@ final class CleanupObserver<ENTITY> implements Observer<ENTITY>
      * @param requests Stateful storage of in-flight requests.
      * @param key Key to remove observables of on completion.
      */
-    public CleanupObserver(HashMap<String, Observable<ENTITY>> requests, String key)
+    public CleanupObserver(HashMap<String, PublishSubject<ENTITY>> requests, String key)
     {
         this.requests = requests;
         this.key = key;


### PR DESCRIPTION
There was an issue with the in-flight requests not being stored as
composite requests. This fixes that and should help prevent duplicate
requests.

---

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | N/A |
