### PR TITLE
Fix management of child requests in subjects.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.netflix.rxjava:rxjava-android:0.20.7'
+    compile 'io.reactivex:rxjava:1.0.8'
     provided 'commons-logging:commons-logging:1.2'
 }
 

--- a/src/main/java/com/inkapplications/groundcontrol/CompleteCleanup.java
+++ b/src/main/java/com/inkapplications/groundcontrol/CompleteCleanup.java
@@ -5,11 +5,7 @@
 package com.inkapplications.groundcontrol;
 
 import org.apache.commons.logging.Log;
-import rx.Observable;
-import rx.Observer;
-import rx.subjects.PublishSubject;
-
-import java.util.HashMap;
+import rx.functions.Action0;
 
 /**
  * Observer for removing completed requests in a collection.
@@ -20,14 +16,15 @@ import java.util.HashMap;
  * on completion of the request.
  *
  * @param <ENTITY> The subscription entity type that this is bound to.
+ * @author Maxwell Vandervelde (Max@MaxVandervelde.com)
  */
-final class CleanupObserver<ENTITY> implements Observer<ENTITY>
+final class CompleteCleanup<ENTITY> implements Action0
 {
     /** Log cleanup callback events. */
     final private Log logger;
 
     /** Stateful storage of in-flight requests. */
-    final private HashMap<String, PublishSubject<ENTITY>> requests;
+    final private RequestCollection<ENTITY> requests;
 
     /** Key to remove observables of on completion. */
     final private String key;
@@ -36,20 +33,20 @@ final class CleanupObserver<ENTITY> implements Observer<ENTITY>
      * @param requests Stateful storage of in-flight requests.
      * @param key Key to remove observables of on completion.
      */
-    public CleanupObserver(Log logger, HashMap<String, PublishSubject<ENTITY>> requests, String key)
-    {
+    public CompleteCleanup(
+        Log logger,
+        RequestCollection<ENTITY> requests,
+        String key
+    ) {
         this.logger = logger;
         this.requests = requests;
         this.key = key;
     }
 
     @Override
-    public void onCompleted()
+    public void call()
     {
-        this.logger.trace("Cleaning up key: " + key);
+        this.logger.trace("Complete. Cleaning up key: " + key);
         this.requests.remove(this.key);
     }
-
-    @Override public void onError(Throwable e) {}
-    @Override public void onNext(ENTITY entity) {}
 }

--- a/src/main/java/com/inkapplications/groundcontrol/CompositeRequestManager.java
+++ b/src/main/java/com/inkapplications/groundcontrol/CompositeRequestManager.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2015 Ink Applications, LLC.
+ * Distributed under the MIT License (http://opensource.org/licenses/MIT)
+ */
+package com.inkapplications.groundcontrol;
+
+import rx.Observable;
+import rx.Observer;
+import rx.Subscription;
+import rx.functions.Action0;
+import rx.subjects.ReplaySubject;
+
+/**
+ * Handles subscribing, unsubscribing and tracking of combined requests.
+ *
+ * The in-flight requests for the library are stored as composite subjects that
+ * contain multiple subscriptions. When one of these subscriptions is canceled,
+ * we need to check if there are any other subscriptions in the composite
+ * before the entire subject can be canceled.
+ * RxJava's subjects lack the ability to gain insights on the state of the
+ * subject. So, as a solution, this class manages the main subscription
+ * and the subscriptions within it.
+ * We keep track of the number of subscriptions here so that a safe unsubscribe
+ * can be done as a cleanup when one of the children unsubscribes.
+ *
+ * @param <ENTITY> The type of data being managed in the composite request.
+ * @author Maxwell Vandervelde (Max@MaxVandervelde.com)
+ */
+public class CompositeRequestManager<ENTITY>
+{
+    /** The subject containing multiple child subjects. */
+    final private ReplaySubject<ENTITY> composite;
+
+    /** The subscription to cancel the main composite subject. */
+    final private Subscription subscription;
+
+    /** Action performed when a child unsubscribes. */
+    final private Action0 unsubscribeAction;
+
+    /** The number of child subjects in the composite. */
+    private int subscriptions = 0;
+
+    /**
+     * @param composite The subject containing multiple child subjects.
+     * @param subscription The subscription to cancel the main composite subject.
+     * @param unsubscribeAction Action performed when a child unsubscribes.
+     */
+    public CompositeRequestManager(
+        ReplaySubject<ENTITY> composite,
+        Subscription subscription,
+        Action0 unsubscribeAction
+    ) {
+        this.composite = composite;
+        this.subscription = subscription;
+        this.unsubscribeAction = unsubscribeAction;
+    }
+
+    /**
+     * Subscribe a new observer to the composite request.
+     *
+     * This will subscribe the observer to the bound subject and add the bound
+     * unsubscribe action.
+     *
+     * @param observer The observer to subscribe to the request.
+     * @return A subscription to cancel updates for the specified observer, not the whole subject.
+     */
+    public Subscription subscribe(Observer<ENTITY> observer)
+    {
+        this.subscriptions++;
+
+        Observable<ENTITY> observable = this.composite.doOnUnsubscribe(this.unsubscribeAction);
+
+        return observable.subscribe(observer);
+    }
+
+    /**
+     * Cancel the subscription for the main composite subject.
+     */
+    final public void unsubscribe()
+    {
+        this.subscription.unsubscribe();
+    }
+
+    /**
+     * Notify that a child subscription has been cancelled.
+     *
+     * This decreases the subscription count that is tracked by this object. It
+     * should be called from the unsubscribe action bound to this class.
+     */
+    final public void removeSubscription()
+    {
+        this.subscriptions--;
+    }
+
+    /**
+     * Get the number of subscribers that are still observing the composite subject.
+     *
+     * @return The number of subscribers observing the subject.
+     */
+    final public int subscriberCount()
+    {
+        return this.subscriptions;
+    }
+}

--- a/src/main/java/com/inkapplications/groundcontrol/RequestCollection.java
+++ b/src/main/java/com/inkapplications/groundcontrol/RequestCollection.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2015 Ink Applications, LLC.
+ * Distributed under the MIT License (http://opensource.org/licenses/MIT)
+ */
+package com.inkapplications.groundcontrol;
+
+import java.util.HashMap;
+
+/**
+ * Defines the collection type used for storing key/value pairs to lookup request managers.
+ *
+ * @param <ENTITY> The type of data being managed in the composite request.
+ * @author Maxwell Vandervelde (Max@MaxVandervelde.com)
+ */
+final class RequestCollection<ENTITY> extends HashMap<String, CompositeRequestManager<ENTITY>> {}

--- a/src/main/java/com/inkapplications/groundcontrol/UnsubscribeCleanup.java
+++ b/src/main/java/com/inkapplications/groundcontrol/UnsubscribeCleanup.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2015 Ink Applications, LLC.
+ * Distributed under the MIT License (http://opensource.org/licenses/MIT)
+ */
+package com.inkapplications.groundcontrol;
+
+import org.apache.commons.logging.Log;
+import rx.functions.Action0;
+
+/**
+ * Observer for removing completed requests in a collection.
+ *
+ * this is used to clean up the collection of "in-flight" requests after it is
+ * completed in the subscription factory.
+ * The requests collection here is stateful, an this observer will modify it
+ * on completion of the request.
+ *
+ * @param <ENTITY> The subscription entity type that this is bound to.
+ * @author Maxwell Vandervelde (Max@MaxVandervelde.com)
+ */
+final class UnsubscribeCleanup<ENTITY> implements Action0
+{
+    /** Log cleanup callback events. */
+    final private Log logger;
+
+    /** Stateful storage of in-flight requests. */
+    final private RequestCollection<ENTITY> requests;
+
+    /** Key to remove observables of on completion. */
+    final private String key;
+
+    /**
+     * @param requests Stateful storage of in-flight requests.
+     * @param key Key to remove observables of on completion.
+     */
+    public UnsubscribeCleanup(
+        Log logger,
+        RequestCollection<ENTITY> requests,
+        String key
+    ) {
+        this.logger = logger;
+        this.requests = requests;
+        this.key = key;
+    }
+
+    @Override
+    public void call()
+    {
+        this.logger.trace("Subject Unsubscribed.");
+
+        CompositeRequestManager<ENTITY> manager = this.requests.get(this.key);
+        if (null == manager) {
+            this.logger.debug("Key already clean.");
+            return;
+        }
+
+        if (manager.subscriberCount() > 1) {
+            this.logger.debug("Still observing. Keeping subject alive.");
+            manager.removeSubscription();
+            return;
+        }
+
+        this.logger.trace("Cleaning up key: " + key);
+        this.requests.remove(this.key);
+        manager.unsubscribe();
+    }
+}

--- a/src/main/java/com/inkapplications/groundcontrol/Worker.java
+++ b/src/main/java/com/inkapplications/groundcontrol/Worker.java
@@ -12,6 +12,7 @@ import java.sql.SQLException;
  * A service that looks up data locally.
  *
  * @param <YIELD> The type of data that the worker will lookup and return.
+ * @author Maxwell Vandervelde (Max@MaxVandervelde.com)
  */
 public interface Worker<YIELD> extends Observable.OnSubscribe<YIELD>
 {


### PR DESCRIPTION
There was an issue with the incorrect subscriptions being returned
from the subscription factory. The subscriptions for new requests
has been fixed and the main subscription is now managed and canceled
from unsubscribers.
Because of the way the subjects work in RxJava, a lot of work had
to be done to monitor the state of subscriptions inside of a
subject inside the `CompositeRequestManager` class.
Subjects were also changed to replaysubjects, since that makes more
sense for data lookups.
